### PR TITLE
Deprecate **additional_data in utility functions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -160,8 +160,10 @@ rohrpost provides three main helper methods for message sending in
     provide any, an integer will be randomly chosen.
   - ``close``: Set to ``True`` if you want to close the connection.
   - ``error``: Include an error message or error content
+  - ``data``: A dict that will appear in the message as ``data`` (converted to
+    a JSON object).
   - ``**additional_data``: Any other keyword argument will appear in the
-    message's ``data`` field as a JSON object.
+    message's ``data`` field as a JSON object.  This is deprecated.
 
 - ``rohrpost.message.send_error`` sends an error message explicitly, takes the
   same arguments as ``send_message``.

--- a/rohrpost/handlers.py
+++ b/rohrpost/handlers.py
@@ -24,15 +24,11 @@ def handle_ping(message, request):
     Caution: if the sent data is not a dict, it will be wrapped in an
     additional "data" object in the response.
     """
-    response_kwargs = {
-        "message": message,
-        "message_id": request["id"],
-        "handler": "pong",
-    }
+    data = None
     if "data" in request:
         if isinstance(request["data"], dict):
-            response_kwargs.update(request["data"])
+            data = request["data"]
         else:
-            response_kwargs["data"] = request["data"]
+            data = {"data": request["data"]}
 
-    send_message(**response_kwargs)
+    send_message(message=message, message_id=request["id"], handler="pong", data=data)

--- a/rohrpost/message.py
+++ b/rohrpost/message.py
@@ -3,6 +3,12 @@ import random
 from decimal import Decimal
 
 
+def deprecate(message):
+    import warnings
+
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+
 class TolerantJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         import uuid
@@ -21,7 +27,13 @@ def _send_message(*, message, content: dict, close: bool):
 
 
 def build_message(
-    *, handler, message_id=None, error=None, generate_id=False, **additional_data
+    *,
+    handler,
+    message_id=None,
+    error=None,
+    generate_id=False,
+    data: dict = None,
+    **additional_data
 ):
     content = dict()
     if message_id:
@@ -33,16 +45,37 @@ def build_message(
         content["type"] = handler
     if error:
         content["error"] = error
-    if additional_data:
-        content["data"] = additional_data
+    if data or additional_data:
+        content["data"] = data or {}
+        if additional_data:
+            deprecate(
+                "Passing arbitrary kwargs to `build_message()` is depreated."
+                " Pass in a dict `data` instead."
+            )
+            content["data"].update(additional_data)
     return content
 
 
 def send_message(
-    *, message, handler, message_id=None, close=False, error=None, **additional_data
+    *,
+    message,
+    handler,
+    message_id=None,
+    close=False,
+    error=None,
+    data: dict = None,
+    **additional_data
 ):
+    if additional_data:
+        deprecate(
+            "Passing arbitrary kwargs to `send_message()` is depreated."
+            " Pass in a dict `data` instead."
+        )
+        if data is None:
+            data = {}
+        data.update(additional_data)
     content = build_message(
-        handler=handler, message_id=message_id, error=error, **additional_data
+        handler=handler, message_id=message_id, error=error, data=data
     )
 
     if not content:
@@ -50,7 +83,9 @@ def send_message(
     _send_message(message=message, content=content, close=close)
 
 
-def send_success(*, message, handler, message_id, close=False, **additional_data):
+def send_success(
+    *, message, handler, message_id, close=False, data: dict = None, **additional_data
+):
     """
     This method directly wraps send_message but checks the existence of id and type.
     """
@@ -59,24 +94,47 @@ def send_success(*, message, handler, message_id, close=False, **additional_data
             "You have to provide a message ID and handler on success messages."
         )
 
+    if additional_data:
+        deprecate(
+            "Passing arbitrary kwargs to `send_success()` is depreated."
+            " Pass in a dict `data` instead."
+        )
+        if data is None:
+            data = {}
+        data.update(additional_data)
+
     send_message(
-        message=message,
-        message_id=message_id,
-        handler=handler,
-        close=close,
-        **additional_data
+        message=message, message_id=message_id, handler=handler, close=close, data=data
     )
 
 
-def send_error(*, message, handler, message_id, error, close=False, **additional_data):
+def send_error(
+    *,
+    message,
+    handler,
+    message_id,
+    error,
+    close=False,
+    data: dict = None,
+    **additional_data
+):
     """
     This method wraps send_message and makes sure that error is a keyword argument.
     """
+    if additional_data:
+        deprecate(
+            "Passing arbitrary kwargs to `send_error()` is depreated."
+            " Pass in a dict `data` instead."
+        )
+        if data is None:
+            data = {}
+        data.update(additional_data)
+
     send_message(
         message=message,
         message_id=message_id,
         handler=handler,
         error=error,
         close=close,
-        **additional_data
+        data=data,
     )

--- a/rohrpost/mixins.py
+++ b/rohrpost/mixins.py
@@ -64,7 +64,7 @@ class NotifyBase:
         payload = {
             "text": json.dumps(
                 build_message(
-                    generate_id=True, handler="subscription-update", **message_data
+                    generate_id=True, handler="subscription-update", data=message_data
                 ),
                 cls=self.encoder,
             )

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -16,7 +16,7 @@ def test_ping_additional_data(message):
     handle_ping(message, request={
         'id': 123,
         'type': 'ping',
-        'data': {'some': 'data', 'other': 'data'}
+        'data': {'some': 'data', 'other': 'data', 'handler': 'foo'}
     })
     assert message.reply_channel.closed is False
     assert len(message.reply_channel.data) == 1
@@ -25,6 +25,7 @@ def test_ping_additional_data(message):
     assert data['id'] == 123
     assert data['type'] == 'pong'
     assert data['data']['some'] == 'data'
+    assert data['data']['handler'] == 'foo'
 
 
 def test_ping_additional_non_dict_data(message):


### PR DESCRIPTION
The functions in `message.py` should not accept arbitrary kwargs, but one kwarg `data` with arbitrary data as a dict.  This prevents the data from clashing with the actual kwargs.